### PR TITLE
Fix the typo on `plugin-logger`'s import and add a warning to CLI guide

### DIFF
--- a/docs/Guide/CLI/getting-started.mdx
+++ b/docs/Guide/CLI/getting-started.mdx
@@ -19,6 +19,12 @@ utility in multiple projects.
 
 :::
 
+:::danger
+
+CLI requires Node 16.7 or higher.
+
+:::
+
 <details id="new-project">
 <summary>Setting up a new project</summary>
 

--- a/docs/Guide/plugins/Logger/getting-started.mdx
+++ b/docs/Guide/plugins/Logger/getting-started.mdx
@@ -25,7 +25,7 @@ This registers the necessary options and methods in the Sapphire client to be ab
 ```javascript
 // Main bot file
 // Be sure to register the plugin before instantiating the client.
-require('@sapphire/plugin-api/register');
+require('@sapphire/plugin-logger/register');
 ```
 
 </TabItem>
@@ -35,7 +35,7 @@ require('@sapphire/plugin-api/register');
 ```javascript
 // Main bot file
 // Be sure to register the plugin before instantiating the client.
-import '@sapphire/plugin-api/register';
+import '@sapphire/plugin-logger/register';
 ```
 
 </TabItem>
@@ -45,7 +45,7 @@ import '@sapphire/plugin-api/register';
 ```typescript
 // Main bot file
 // Be sure to register the plugin before instantiating the client.
-import '@sapphire/plugin-api/register';
+import '@sapphire/plugin-logger/register';
 ```
 
 </TabItem>


### PR DESCRIPTION
I added that warning because I saw more than 3 people using older versions of Node and having issues.