### PR TITLE
fix: a confusion about latest and next versions

### DIFF
--- a/docs/General/Welcome.mdx
+++ b/docs/General/Welcome.mdx
@@ -23,7 +23,7 @@ The [`@sapphire/framework` API documentation][frameworksdocs] section of this we
 branch of [`@sapphire/framework`][saphfw]. This means it will mention any breaking changes that are not yet released to
 NPM, including but not limited to support for Application Commands. In the grand scheme of things, this means that the
 API documentation may show properties, functions and classes that will not be available until the next major release of
-[`@sapphire/framework`][saphfw]. That said, if you wish to use the latest version of [`@sapphire/framework`][saphfw] in
+[`@sapphire/framework`][saphfw]. That said, if you wish to use this next version of [`@sapphire/framework`][saphfw] in
 your project, you can install it by using the `@next` tag from NPM.
 
 ```bash npm2yarn2pnpm


### PR DESCRIPTION
I also replaced "the" with "this" as a way to confirm that the version we're talking about is the one mentioned earlier as the one of the documentation