### PR TITLE
fix: guide order and references to previous parts

### DIFF
--- a/docs/Guide/listeners/creating-your-own-listeners.mdx
+++ b/docs/Guide/listeners/creating-your-own-listeners.mdx
@@ -4,7 +4,8 @@ title: Creating your own listeners
 ---
 
 Similar to what you learned in both [Creating Commands][creating-commands] and [Creating Preconditions][creating-preconditions],
-we will create a `listeners` subdirectory in your project's entry point directory. In this document, we'll make a `ready` event listener.
+we will create a `listeners` subdirectory in your project's entry point directory.
+In this document, we'll make a `ready` event listener.
 
 Your directory should now look something like this:
 

--- a/docs/Guide/listeners/creating-your-own-listeners.mdx
+++ b/docs/Guide/listeners/creating-your-own-listeners.mdx
@@ -3,9 +3,9 @@ sidebar_position: 1
 title: Creating your own listeners
 ---
 
-Similar to what you learned in both [Creating Commands][creating-commands] and [Creating Preconditions][creating-preconditions],
-we will create a `listeners` subdirectory in your project's entry point directory.
-In this document, we'll make a `ready` event listener.
+Similar to what you learned in both [Creating Commands][creating-commands] and [Creating
+Preconditions][creating-preconditions], we will create a `listeners` subdirectory in your project's entry point
+directory. In this document, we'll make a `ready` event listener.
 
 Your directory should now look something like this:
 

--- a/docs/Guide/listeners/creating-your-own-listeners.mdx
+++ b/docs/Guide/listeners/creating-your-own-listeners.mdx
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Creating your own listeners
 ---
 
-Similar to what you learned in [Creating Commands][creating-commands], we will create a `listeners` subdirectory in your
+Similar to what you learned in both [Creating Commands][creating-commands] and [Creating Preconditions][creating-preconditions], we will create a `listeners` subdirectory in your
 project's entry point directory. In this document, we'll make a `ready` event listener.
 
 Your directory should now look something like this:
@@ -104,3 +104,4 @@ name them `guildMemberAddSendLog` and `guildMemberAddSendGreeting` respectively,
 `{ event: 'guildMemberAdd' }` in both of their options.
 
 [creating-commands]: ../getting-started/creating-a-basic-command
+[creating-preconditions]: ../preconditions/creating-your-own-preconditions

--- a/docs/Guide/listeners/creating-your-own-listeners.mdx
+++ b/docs/Guide/listeners/creating-your-own-listeners.mdx
@@ -3,8 +3,8 @@ sidebar_position: 1
 title: Creating your own listeners
 ---
 
-Similar to what you learned in both [Creating Commands][creating-commands] and [Creating Preconditions][creating-preconditions], we will create a `listeners` subdirectory in your
-project's entry point directory. In this document, we'll make a `ready` event listener.
+Similar to what you learned in both [Creating Commands][creating-commands] and [Creating Preconditions][creating-preconditions],
+we will create a `listeners` subdirectory in your project's entry point directory. In this document, we'll make a `ready` event listener.
 
 Your directory should now look something like this:
 

--- a/docs/Guide/preconditions/creating-your-own-preconditions.mdx
+++ b/docs/Guide/preconditions/creating-your-own-preconditions.mdx
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Creating your own preconditions
 ---
 
-Just as we did in both [Creating Commands][creating-commands], we will start by creating a `preconditions` subdirectory
+Just as we did in [Creating Commands][creating-commands], we will start by creating a `preconditions` subdirectory
 in your project's entry point directory. For this guide, we'll be building out an `OwnerOnly` precondition, that
 prevents anyone but the application owner from running the command.
 

--- a/docs/Guide/preconditions/creating-your-own-preconditions.mdx
+++ b/docs/Guide/preconditions/creating-your-own-preconditions.mdx
@@ -3,9 +3,9 @@ sidebar_position: 1
 title: Creating your own preconditions
 ---
 
-Just as we did in [Creating Commands][creating-commands], we will start by creating a `preconditions` subdirectory
-in your project's entry point directory. For this guide, we'll be building out an `OwnerOnly` precondition, that
-prevents anyone but the application owner from running the command.
+Just as we did in [Creating Commands][creating-commands], we will start by creating a `preconditions` subdirectory in
+your project's entry point directory. For this guide, we'll be building out an `OwnerOnly` precondition, that prevents
+anyone but the application owner from running the command.
 
 Your directory should now look something like this:
 

--- a/docs/Guide/preconditions/creating-your-own-preconditions.mdx
+++ b/docs/Guide/preconditions/creating-your-own-preconditions.mdx
@@ -3,9 +3,9 @@ sidebar_position: 1
 title: Creating your own preconditions
 ---
 
-Just as we did in both [Creating Commands][creating-commands], we will
-start by creating a `preconditions` subdirectory in your project's entry point directory. For this guide, we'll be
-building out an `OwnerOnly` precondition, that prevents anyone but the application owner from running the command.
+Just as we did in both [Creating Commands][creating-commands], we will start by creating a `preconditions` subdirectory
+in your project's entry point directory. For this guide, we'll be building out an `OwnerOnly` precondition, that
+prevents anyone but the application owner from running the command.
 
 Your directory should now look something like this:
 

--- a/docs/Guide/preconditions/creating-your-own-preconditions.mdx
+++ b/docs/Guide/preconditions/creating-your-own-preconditions.mdx
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Creating your own preconditions
 ---
 
-Just as we did in both [Creating Commands][creating-commands] and [Creating Listeners][creating-listeners], we will
+Just as we did in both [Creating Commands][creating-commands], we will
 start by creating a `preconditions` subdirectory in your project's entry point directory. For this guide, we'll be
 building out an `OwnerOnly` precondition, that prevents anyone but the application owner from running the command.
 
@@ -122,7 +122,6 @@ For a command with these preconditions to pass the denial checks, the `InVoiceCh
 as `AdminOnly` _or_ both `OwnerOnly` and `ModOnly`.
 
 [creating-commands]: ../getting-started/creating-a-basic-command
-[creating-listeners]: ../listeners/creating-your-own-listeners
 [precondition]: ../../Documentation/api-framework/classes/Precondition
 [preconditionrun]: ../../Documentation/api-framework/classes/Precondition#messagerun
 [preconditionok]: ../../Documentation/api-framework/classes/Precondition#ok


### PR DESCRIPTION
The "Preconditions" part of the guide comes before the "Listeners" one, so the narrative "Just as we did in (...) Creating Listeners" seems incorrect.
And vice-versa