### PR TITLE
fix: remove `times` when not necessary

### DIFF
--- a/docs/Guide/arguments/using-arguments.mdx
+++ b/docs/Guide/arguments/using-arguments.mdx
@@ -178,8 +178,7 @@ instance, a number may fail to parse if the user did not provide a valid number.
 ## Repeating arguments
 
 To work with repeating arguments, you can use [`args.repeat()`][repeat], which works like [`args.pick()`][pick] but
-returns an array of parsed elements, resolving when it can validate at least the
-first argument.
+returns an array of parsed elements, resolving when it can validate at least the first argument.
 
 ```typescript ts2esm2cjs|{5}|{6}
 import { Command, Args } from '@sapphire/framework';

--- a/docs/Guide/arguments/using-arguments.mdx
+++ b/docs/Guide/arguments/using-arguments.mdx
@@ -178,7 +178,7 @@ instance, a number may fail to parse if the user did not provide a valid number.
 ## Repeating arguments
 
 To work with repeating arguments, you can use [`args.repeat()`][repeat], which works like [`args.pick()`][pick] but
-returns an array of parsed elements up to the desired amount of `times`, resolving when it can validate at least the
+returns an array of parsed elements, resolving when it can validate at least the
 first argument.
 
 ```typescript ts2esm2cjs|{5}|{6}


### PR DESCRIPTION
The option is not used right away but later, so mentioning it here is confusing