### PR TITLE
fix(guide-i18n): `resolveKey` example

### DIFF
--- a/docs/Guide/plugins/i18next/getting-started.mdx
+++ b/docs/Guide/plugins/i18next/getting-started.mdx
@@ -142,7 +142,7 @@ export class PingCommand extends Command {
   }
 
   public async messageRun(message: Message) {
-    await message.channel.send(await resolveKey(message.guild!, 'ping:success'));
+    await message.channel.send(await resolveKey(message, 'ping:success'));
   }
 }
 ```

--- a/docs/Guide/plugins/i18next/getting-started.mdx
+++ b/docs/Guide/plugins/i18next/getting-started.mdx
@@ -142,7 +142,7 @@ export class PingCommand extends Command {
   }
 
   public async messageRun(message: Message) {
-    await message.channel.send(await resolveKey('ping:success'));
+    await message.channel.send(await resolveKey(message.guild!, 'ping:success'));
   }
 }
 ```

--- a/docs/Guide/plugins/i18next/getting-started.mdx
+++ b/docs/Guide/plugins/i18next/getting-started.mdx
@@ -229,7 +229,5 @@ export class PingCommand extends Command {
 ```
 
 [`saphclientoptions`]: ../../../Documentation/api-framework/interfaces/SapphireClientOptions
-[`fetchlanguage`]:
-  ../../../Documentation/api-plugins/classes/i18next_src.InternationalizationHandler#fetchlanguage
-[`internationalizationcontext`]:
-  ../../../Documentation/api-plugins/interfaces/i18next_src.InternationalizationContext
+[`fetchlanguage`]: ../../../Documentation/api-plugins/classes/i18next_src.InternationalizationHandler#fetchlanguage
+[`internationalizationcontext`]: ../../../Documentation/api-plugins/interfaces/i18next_src.InternationalizationContext


### PR DESCRIPTION
Current example raises -
```ts
Expected 2-3 arguments, but got 1.ts(2554)
[functions.d.ts(33, 185): ]()An argument for 'key' was not provided.
```

Which is because example isn't specifying to resolve key for what, fixed it by specifying `message.guild`.