### PR TITLE
docs: clarify discordjs version limitation

### DIFF
--- a/docs/General/Welcome.mdx
+++ b/docs/General/Welcome.mdx
@@ -57,7 +57,7 @@ become the ultimate modern experience of writing your code.
 **Node.js 16.6.0 or newer is required.**
 
 ```bash npm2yarn2pnpm
-npm install @sapphire/framework discord.js@13.9.1
+npm install @sapphire/framework discord.js@v13-lts
 ```
 
 ### Optional packages

--- a/docs/General/Welcome.mdx
+++ b/docs/General/Welcome.mdx
@@ -57,7 +57,7 @@ become the ultimate modern experience of writing your code.
 **Node.js 16.6.0 or newer is required.**
 
 ```bash npm2yarn2pnpm
-npm install @sapphire/framework discord.js
+npm install @sapphire/framework discord.js@13.9.1
 ```
 
 ### Optional packages

--- a/docs/Guide/getting-started/getting-started-with-sapphire.mdx
+++ b/docs/Guide/getting-started/getting-started-with-sapphire.mdx
@@ -33,7 +33,7 @@ Here is an example of a package.json file:
   "main": "src/index.js",
   "dependencies": {
     "@sapphire/framework": "latest",
-    "discord.js": "^13.9.0"
+    "discord.js": "v13-lts"
   },
   "scripts": {
     "start": "node src/index.js"

--- a/docs/Guide/getting-started/getting-started-with-sapphire.mdx
+++ b/docs/Guide/getting-started/getting-started-with-sapphire.mdx
@@ -33,7 +33,7 @@ Here is an example of a package.json file:
   "main": "src/index.js",
   "dependencies": {
     "@sapphire/framework": "latest",
-    "discord.js": "latest"
+    "discord.js": "^13.9.0"
   },
   "scripts": {
     "start": "node src/index.js"


### PR DESCRIPTION
As the framework only supports DiscordJS v13 (not latest: v14), it would be appropriate to set the working version in the documentation example.