### PR TITLE
fix: add missing import in exapmle

### DIFF
--- a/docs/Guide/listeners/listening-to-events-emitted-by-other-emitters.mdx
+++ b/docs/Guide/listeners/listening-to-events-emitted-by-other-emitters.mdx
@@ -25,7 +25,7 @@ export class RawGuildMemberAddListener extends Listener {
 The other way is to specify an emitter directly instead of a property name:
 
 ```typescript ts2esm2cjs|{7-8}|{7-8}
-import { Listener } from '@sapphire/framework';
+import { Listener, container } from '@sapphire/framework';
 
 export class RawGuildMemberAddListener extends Listener {
   public constructor(context: Listener.Context, options: Listener.Options) {


### PR DESCRIPTION
When compiling the example code I get an error `Cannot find name 'container'. Did you mean the instance member 'this.container'?` and the fix was to add an import for `container`