### PR TITLE
docs: update component templates and example

### DIFF
--- a/docs/Guide/CLI/generating-components.md
+++ b/docs/Guide/CLI/generating-components.md
@@ -15,12 +15,14 @@ sapphire generate <component> <name>
 Example:
 
 ```bash
-sapphire generate command HelloWorld
+sapphire generate messagecommand HelloWorld
 ```
 
 ## Default components
 
-- `command`
+- `messagecommand`
+- `slashcommand`
+- `contextmenucommand`
 - `listener`
 - `argument`
 - `precondition`


### PR DESCRIPTION
Adds the 2 new templates for CLI components and updated `command` component to `messagecommand`.