### PR TITLE
chore: update the 'idHints' section of 'Registering Chat Input Commands'

### DIFF
--- a/docs/Guide/application-commands/application-command-registry/registering-chat-input-commands.mdx
+++ b/docs/Guide/application-commands/application-command-registry/registering-chat-input-commands.mdx
@@ -122,6 +122,8 @@ default logger provided by `Sapphire`. The command ID is logged on the `info` le
 you have configured the Sapphire Logger to only log errors or fatal messages then please check
 [`Configuring Log Level Guide`][configure-logging] to learn how to change it.
 
+**Note:** The command ID should be logged on every load of the framework (e.g. at every `npm start`). However, it might be logged only **once** on the `info` level (right after a successful registration). If that's the case and you need to find the ID, we recommend switching to the `debug` level and check if it is logged there.
+
 ### `guildIds`
 
 This is an array of guild ids for which the command should be registered. By default it is `undefined`, which means that


### PR DESCRIPTION
The command ID seems to be logged on the `info` level only after a successful command registration. Any subsequent re-runs of the Node script/bot will log the command ID on the `debug` level (from what I've experienced). Not sure whether this is a bug or it is working as expected, though. If it's a bug, feel free to reject this PR, once it is fixed.

Thank you for an amazing framework! 🎉 