### PR TITLE
docs: update getting started app command guides

### DIFF
--- a/docs/Guide/application-commands/application-command-registry/registering-chat-input-commands.mdx
+++ b/docs/Guide/application-commands/application-command-registry/registering-chat-input-commands.mdx
@@ -3,9 +3,11 @@ sidebar_position: 3
 title: Registering Chat Input Commands
 ---
 
-:::caution To register a Chat Input Command (also known as a Slash Command) with Discord, you need to acquire an
-application command registry. If you missed how to do it, please see the
-[`Acquiring an Application Command Registry`][aaacr] section for more details.
+:::caution
+
+To register a Chat Input Command (also known as a Slash Command) with Discord, you need to acquire an application
+command registry. If you missed how to do it, please see the [`Acquiring an Application Command Registry`][aaacr]
+section for more details.
 
 :::
 

--- a/docs/Guide/application-commands/what-are-application-commands.mdx
+++ b/docs/Guide/application-commands/what-are-application-commands.mdx
@@ -1,0 +1,29 @@
+---
+sidebar_position: 0
+title: What are application commands?
+---
+
+If you've been around for a while, you know that the conventional way of interacting with Discord bots is through
+messaging, either by pinging one or starting a message with a prefix like `$` or `!`.
+
+These days, setting up [Application Commands][discord-application-command-docs] are now recommended for Discord bots.
+Instead of worrying about issues like prefix conflicts or argument parsing, Discord now provides native interfaces to
+interact with your bot in the form of slash commands, message context commands, and user context commands.
+
+:::info
+
+If your bot isn't verified (a requirement to be in 100+ servers), then you aren't required to set up application
+commands and can still use classical message commands. This has been a long change in the making that Discord discusses
+in their [Message Content Priviledged Intent FAQ][message-content-faq]. However, application commands generally provide
+a better user experience for most situations, and we recommend you take advantage of them.
+
+:::
+
+Setting up application commands is more involved than message commands, but Sapphire will help register and manage
+application commands for your bot! Even though we handle most of the work, there are still things you should know
+starting with the [Application Command Registry][what-is-it], the next section!
+
+[discord-application-command-docs]: https://discord.com/developers/docs/interactions/application-commands
+[message-content-faq]:
+  https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ
+[what-is-it]: ./application-command-registry/what-is-it.mdx

--- a/docs/Guide/application-commands/what-are-application-commands.mdx
+++ b/docs/Guide/application-commands/what-are-application-commands.mdx
@@ -6,16 +6,16 @@ title: What are application commands?
 If you've been around for a while, you know that the conventional way of interacting with Discord bots is through
 messaging, either by pinging one or starting a message with a prefix like `$` or `!`.
 
-These days, setting up [Application Commands][discord-application-command-docs] are now recommended for Discord bots.
-Instead of worrying about issues like prefix conflicts or argument parsing, Discord now provides native interfaces to
+These days, setting up [Application Commands][discord-application-command-docs] is now recommended for Discord bots.
+Instead of worrying about issues like prefix conflicts or argument parsing, Discord now provides a native interface to
 interact with your bot in the form of slash commands, message context commands, and user context commands.
 
 :::info
 
 If your bot isn't verified (a requirement to be in 100+ servers), then you aren't required to set up application
-commands and can still use classical message commands. This has been a long change in the making that Discord discusses
-in their [Message Content Priviledged Intent FAQ][message-content-faq]. However, application commands generally provide
-a better user experience for most situations, and we recommend you take advantage of them.
+commands and can still use legacy message commands. This has been a long change in the making that Discord addresses in
+their [Message Content Priviledged Intent FAQ][message-content-faq]. However, application commands generally provide a
+better user experience for most situations, and we recommend you take advantage of them.
 
 :::
 

--- a/docs/Guide/getting-started/creating-a-basic-app-command.mdx
+++ b/docs/Guide/getting-started/creating-a-basic-app-command.mdx
@@ -69,46 +69,6 @@ export class PingCommand extends Command {
 
 ## Creating a slash command with subcommands
 
-:::caution
-
-Currently, progress is still being made on the official [Sapphire Subcommands Plugin][saph-plug-subcom]. The following
-example works as of now, and will continue to work after the plugin is updated. However, creating subcommands will be
-possible with less code once the plugin has been updated.
-
-:::
-
-To create a slash command with subcommands, we need to add additional configuration while implementing the
-`registerApplicationCommands` method for the `Command` class.
-
-`Example`
-
-```typescript ts2esm2cjs|{12-20}|{12-20}
-import { Command } from '@sapphire/framework';
-
-export class SubCommand extends Command {
-  public constructor(context: Command.Context, options: Command.Options) {
-    // ...
-  }
-
-  public async chatInputRun(interaction: Command.ChatInputInteraction) {
-    // ...
-  }
-
-  public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('command')
-        .setDescription('Command with subcommands')
-        .addSubcommand((command) => command.setName('first').setDescription('First subcommand'))
-        .addSubcommand((command) => command.setName('second').setDescription('Second subcommand'))
-    );
-  }
-}
-```
-
-The above will create a slash command called `command` with the description `Command with subcommands`. The command will
-have two sub commands, `first` and `second` with description `First subcommand` and `Second subcommand` respectively.
-
 :::note
 
 For handling subcommands, please refer to the [Sapphire Plugin Subcommands][saph-plug-subcom] documentation.

--- a/docs/Guide/getting-started/creating-a-basic-app-command.mdx
+++ b/docs/Guide/getting-started/creating-a-basic-app-command.mdx
@@ -3,12 +3,19 @@ sidebar_position: 2
 title: Creating a basic slash command
 ---
 
-Creating a basic slash command is very similar to creating a basic command. To create a slash command you will have to
-define the `registerApplicationCommands` method in the command class.
+:::caution
 
-For example, let's create a `ping` command:
+This section covers the **absolute minimum** for setting up a slash command. We have an entire "Application Commands"
+section on how to effectively set up slash commands, and if you are doing anything serious we highly recommend you start
+there with [`What are application commands?`][what-are-application-commands]
 
-```typescript ts2esm2cjs|{4-13}|{4-13}
+:::
+
+To create a slash command (known as a Chat Input Command in Sapphire), you will need to implement the
+`registerApplicationCommands` method in the `Command` class. Let's create a `ping` command and register a corresponding
+slash command with Discord:
+
+```typescript ts2esm2cjs|{3-13}|{3-13}
 import { Command } from '@sapphire/framework';
 
 export class PingCommand extends Command {
@@ -24,38 +31,26 @@ export class PingCommand extends Command {
 }
 ```
 
-The above example will create a slash command (Chat Input Command) called `ping` with the description
-`Ping bot to see if it is alive`. Alternatively, we can also use `this.name` and `this.description` to pass the name and
-description to the builder which will take the data from the passed values in command class.
+The example above will register a slash command with Discord called `ping` with the description
+`'Ping bot to see if it is alive'`. This is the information users will see in Discord when interacting with your bot
+through the slash command.
 
-Example:
+In order for your bot to respond to the slash command when it is invoked by a user, you must implement the
+`chatInputRun` method for the `Command` class.
 
-```typescript ts2esm2cjs|{4-13}|{4-13}
-import { Command } from '@sapphire/framework';
-
-export class PingCommand extends Command {
-  public constructor(context: Command.Context, options: Command.Options) {
-    super(context, { ...options, name: 'ping', description: 'Ping bot to see if it is alive' });
-  }
-
-  public override registerApplicationCommands(registry: ChatInputCommand.Registry) {
-    registry.registerChatInputCommand((builder) => builder.setName(this.name).setDescription(this.description));
-  }
-}
-```
-
-## Creating the `chatInputRun` method
-
-To handle the command callback when the Context Menu Command is ran we need to override the `chatInputRun` method of
-command class.
-
-```typescript ts2esm2cjs|{9-19}|{9-19}
+```typescript ts2esm2cjs|{15-25}|{15-25}
 import { isMessageInstance } from '@sapphire/discord.js-utilities';
 import { Command } from '@sapphire/framework';
 
 export class PingCommand extends Command {
   public constructor(context: Command.Context, options: Command.Options) {
-    // ...
+    super(context, { ...options });
+  }
+
+  public override registerApplicationCommands(registry: ChatInputCommand.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder.setName('ping').setDescription('Ping bot to see if it is alive')
+    );
   }
 
   public async chatInputRun(interaction: Command.ChatInputInteraction) {
@@ -76,20 +71,18 @@ export class PingCommand extends Command {
 
 :::caution
 
-Currently, progress is still being made on updating the official [Sapphire Plugin Subcommands][saph-plug-subcom]. This
-section will fully work now, and will continue to work after the plugin is updated. However, once the plugin has been
-updated creating subcommands will be possible with less code.
+Currently, progress is still being made on the official [Sapphire Subcommands Plugin][saph-plug-subcom]. The following
+example works as of now, and will continue to work after the plugin is updated. However, creating subcommands will be
+possible with less code once the plugin has been updated.
 
 :::
 
-To create the slash command with subcommand we need to override the `registerApplicationCommands` method of `Command`
-class. This method is called when the `Client` collects all the slash commands defined in the command directory on
-application startup to register them on the discord API. Let's see a quick example of how to make a slash command with
-subcommands.
+To create a slash command with subcommands, we need to add additional configuration while implementing the
+`registerApplicationCommands` method for the `Command` class.
 
 `Example`
 
-```typescript ts2esm2cjs|{12-21}|{12-28}
+```typescript ts2esm2cjs|{12-20}|{12-20}
 import { Command } from '@sapphire/framework';
 
 export class SubCommand extends Command {
@@ -105,22 +98,22 @@ export class SubCommand extends Command {
     registry.registerChatInputCommand((builder) =>
       builder
         .setName('command')
-        .setDescription('Command with sub commands')
-        .addSubcommand((command) => command.setName('first').setDescription('First sub command'))
-        .addSubcommand((command) => command.setName('second').setDescription('Second sub command'))
+        .setDescription('Command with subcommands')
+        .addSubcommand((command) => command.setName('first').setDescription('First subcommand'))
+        .addSubcommand((command) => command.setName('second').setDescription('Second subcommand'))
     );
   }
 }
 ```
 
-The above will create a slash command called `command` with the description `Command with sub commands`. The command
-will have two sub commands, `first` and `second` with description `First sub command` and `Second sub command`
-respectively.
+The above will create a slash command called `command` with the description `Command with subcommands`. The command will
+have two sub commands, `first` and `second` with description `First subcommand` and `Second subcommand` respectively.
 
 :::note
 
-For handling subcommands please refer to the [Sapphire Plugin Subcommands][saph-plug-subcom] documentation.
+For handling subcommands, please refer to the [Sapphire Plugin Subcommands][saph-plug-subcom] documentation.
 
 :::
 
 [saph-plug-subcom]: ../plugins/Subcommands/getting-started
+[what-are-application-commands]: ../application-commands/what-are-application-commands.mdx

--- a/docs/Guide/getting-started/creating-a-basic-command.mdx
+++ b/docs/Guide/getting-started/creating-a-basic-command.mdx
@@ -136,8 +136,17 @@ export class PingCommand extends Command {
 }
 ```
 
+## Creating subcommands
+
+:::note
+
+For handling subcommands, please refer to the [Sapphire Plugin Subcommands][saph-plug-subcom] documentation.
+
+:::
+
 [command]: ../../Documentation/api-framework/classes/Command
 [commandoptions]: ../../Documentation/api-framework/interfaces/CommandOptions
 [getting-started]: ./getting-started-with-sapphire
 [load-message-commands-option]:
   ../../Documentation/api-framework/interfaces/SapphireClientOptions#loadmessagecommandlisteners
+[saph-plug-subcom]: ../plugins/Subcommands/getting-started

--- a/docs/Guide/getting-started/creating-a-basic-context-menu-command.mdx
+++ b/docs/Guide/getting-started/creating-a-basic-context-menu-command.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Creating a basic Context Menu Command
+title: Creating a basic context menu command
 ---
 
 :::caution

--- a/docs/Guide/getting-started/creating-a-basic-context-menu-command.mdx
+++ b/docs/Guide/getting-started/creating-a-basic-context-menu-command.mdx
@@ -3,12 +3,19 @@ sidebar_position: 3
 title: Creating a basic Context Menu Command
 ---
 
-In order to register Context Menu Commands, we first need to override the `registerApplicationCommands` method. For
-example:
+:::caution
 
-`Example`
+This section covers the **absolute minimum** for setting up a message context menu command. We have an entire
+"Application Commands" section on how to effectively set up context menu commands, and if you are doing anything serious
+we highly recommend you start there with [`What are application commands?`][what-are-application-commands]
 
-```typescript ts2esm2cjs|{5-14}|{5-14}
+:::
+
+To create a Message Context Menu Command (User Context Menu Commands are covered in "Application Commands"), you will
+need to implement the `registerApplicationCommands` method in the `Command` class. Let's create a `ping` command and
+register a corresponding Message Context Menu Command with Discord:
+
+```typescript ts2esm2cjs|{4-16}|{4-16}
 import { Command } from '@sapphire/framework';
 import { ApplicationCommandType } from 'discord-api-types/v9';
 
@@ -27,28 +34,33 @@ export class UserCommand extends Command {
 }
 ```
 
-The above will create a `Context Menu` command called `ping` of `ApplicationCommandType.Message` type.
+The above will create a Message Context Menu Command called `ping`, note that we specified the
+`ApplicationCommandType.Message` type.
 
-## Creating the `contextMenuRun` method
+In order for your bot to respond to the Message Context Menu Command when it is invoked by the user, you must implement
+the `contextMenuRun` method for the `Command` class.
 
-To handle the command callback when the Context Menu Command is ran we need to override the `contextMenuRun` method of
-command class.
-
-```typescript ts2esm2cjs|{8-10}|{9-11}
+```typescript ts2esm2cjs|{17-19}|{17-19}
 import { Command } from '@sapphire/framework';
 import type { Message } from 'discord.js';
 
 export class PingCommand extends Command {
   public constructor(context: Command.Context, options: Command.Options) {
-    // ...
+    super(context, { ...options });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerContextMenuCommand((builder) =>
+      builder //
+        .setName('ping')
+        .setType(ApplicationCommandType.Message)
+    );
   }
 
   public async contextMenuRun(interaction: Command.ContextMenuInteraction) {
     return interaction.reply('Pong');
   }
-
-  public override registerApplicationCommands(registry: Command.Registry) {
-    // ...
-  }
 }
 ```
+
+[what-are-application-commands]: ../application-commands/what-are-application-commands.mdx


### PR DESCRIPTION
Now that #199 has been merged, the application command sections in the "Getting Started" guide should be updated so new readers are aware of where to get detailed information.

This also adds a "What are application commands?" section to smooth the transition into reading about application command registries.