### PR TITLE
fix: update broken discord.js guide link

### DIFF
--- a/docs/Guide/application-commands/application-command-registry/registering-chat-input-commands.mdx
+++ b/docs/Guide/application-commands/application-command-registry/registering-chat-input-commands.mdx
@@ -243,7 +243,7 @@ The `chatInputRun` example above uses [interaction handlers][interaction-handler
   https://discord.com/developers/docs/interactions/application-commands#updating-and-deleting-a-command
 [djs-command-data-docs]: https://discord.js.org/#/docs/discord.js/v13/typedef/ApplicationCommandData
 [djs-slash-builder-docs]: https://discord.js.org/#/docs/builders/0.16.0/class/SlashCommandBuilder
-[djs-slash-command-options]: https://discordjs.guide/interactions/slash-commands.html#options
+[djs-slash-command-options]: https://discordjs.guide/slash-commands/advanced-creation.html#option-types
 [interaction-handlers]: ../interaction-handlers/what-are-they.mdx
 [loglevel-info]: ../../../Documentation/api-framework/enums/LogLevel#info
 [loglevel-debug]: ../../../Documentation/api-framework/enums/LogLevel#debug


### PR DESCRIPTION
The previous link https://discordjs.guide/interactions/slash-commands.html#options sends you to a 404 page, it seems that the new link is: https://discordjs.guide/slash-commands/advanced-creation.html#option-types