### PR TITLE
docs: add information on 'MessageContent' intent

### DIFF
--- a/docs/Guide/getting-started/updating-from-v3-to-v4.mdx
+++ b/docs/Guide/getting-started/updating-from-v3-to-v4.mdx
@@ -27,6 +27,12 @@ noted nonetheless.
 - The `default_permission` option for Application Commands has been removed to match the removal on the discord.js and
   Discord API side.
 
+## DiscordJS specific changes
+
+The new update on how intents are enabled requires you to have `GatewayIntentBits.MessageContent` as an intent if the
+bot uses message commands or requires `content`, `attachments`, `embeds` and `components` from messages, even if you 
+already have `GatewayIntentBits.GuildMessages` in your intents.
+
 [ChatInputCommandInteraction]: https://github.com/sapphiredev/framework/blob/main/src/lib/structures/Command.ts#L822
 [ChatInputInteraction]: https://github.com/sapphiredev/framework/blob/v3.2.0/src/lib/structures/Command.ts#L820
 [CommandOptionsRunTypeEnum]: https://github.com/sapphiredev/framework/blob/main/src/lib/structures/Command.ts#L547

--- a/docs/Guide/getting-started/updating-from-v3-to-v4.mdx
+++ b/docs/Guide/getting-started/updating-from-v3-to-v4.mdx
@@ -30,7 +30,7 @@ noted nonetheless.
 ## DiscordJS specific changes
 
 The new update on how intents are enabled requires you to have `GatewayIntentBits.MessageContent` as an intent if the
-bot uses message commands or requires `content`, `attachments`, `embeds` and `components` from messages, even if you 
+bot uses message commands or requires `content`, `attachments`, `embeds` and `components` from messages, even if you
 already have `GatewayIntentBits.GuildMessages` in your intents.
 
 [ChatInputCommandInteraction]: https://github.com/sapphiredev/framework/blob/main/src/lib/structures/Command.ts#L822


### PR DESCRIPTION
The DiscordJS guide does not cover requiring `GatewayIntentBits.MessageContent` when upgrading to v14, and it caused me issues with message commands earlier.

I got the information about the contents in messages from: https://discordjs.guide/popular-topics/intents.html#enabling-intents