### PR TITLE
fix: typo in reporting precondition failure

### DIFF
--- a/docs/Guide/preconditions/reporting-precondition-failure.mdx
+++ b/docs/Guide/preconditions/reporting-precondition-failure.mdx
@@ -10,7 +10,7 @@ When a precondition fails, it's usually important for the user to know why. For 
 permissions, that should somehow be communicated. However, by default, nothing will happen if a precondition blocks a
 message.
 
-To change this, we'll need to create one or more of `chatInputCommandDenied`, `contexcontextMenuCommandDenied`, and/or
+To change this, we'll need to create one or more of `chatInputCommandDenied`, `contextMenuCommandDenied`, and/or
 `messageCommandDenied` listener, which is triggered when a precondition fails for the respective command type. For more
 information on how to create listeners, see the [`Creating Listeners`][listeners] section.
 


### PR DESCRIPTION
Fixed a typo in which `contextMenuCommandDenied` was spelt incorrectly