### PR TITLE
docs: update intents to use enums

### DIFF
--- a/docs/Guide/additional-information/using-and-extending-container.mdx
+++ b/docs/Guide/additional-information/using-and-extending-container.mdx
@@ -60,6 +60,7 @@ logging in with the `SapphireClient`. This way the database connection can be ac
 ```typescript ts2esm2cjs|{19,25,36}|{20,26,37,44-48}
 import { isGuildBasedChannel } from '@sapphire/discord.js-utilities';
 import { container, SapphireClient } from '@sapphire/framework';
+import { GatewayIntentBits } from 'discord.js';
 import type { Message } from 'discord.js';
 
 // First we extend SapphireClient
@@ -70,7 +71,7 @@ export class MyCustomClient extends SapphireClient {
       caseInsensitiveCommands: true,
       caseInsensitivePrefixes: true,
       defaultPrefix: '!',
-      intents: ['GUILDS', 'GUILD_MESSAGES'],
+      intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
       loadDefaultErrorListeners: false
     });
   }


### PR DESCRIPTION
The intents seem like they haven't been updated for discord.js v14, so I updated them to use enums.

I'm guessing updating this https://www.sapphirejs.dev/docs/Guide/getting-started/updating-from-v2-to-v3#events doesn't matter as it's for Sapphire v3.