### PR TITLE
docs: add a caution about reply requires for interaction

### DIFF
--- a/docs/Guide/preconditions/reporting-precondition-failure.mdx
+++ b/docs/Guide/preconditions/reporting-precondition-failure.mdx
@@ -229,16 +229,16 @@ import { Events, Listener, type ChatInputCommandDeniedPayload, type UserError } 
 
 export class ChatInputCommandDenied extends Listener<typeof Events.ChatInputCommandDenied> {
   public run(error: UserError, { interaction }: ChatInputCommandDeniedPayload) {
-    if (Reflect.get(Object(error.context), 'silent')) return;
+    const isSilent = Reflect.get(Object(error.context), 'silent');
 
     if (interaction.deferred || interaction.replied) {
       return interaction.editReply({
-        content: error.message
+        content: isSilent ? '\u200b' : error.message
       });
     }
 
     return interaction.reply({
-      content: error.message,
+      content: isSilent ? '\u200b' : error.message
       ephemeral: true
     });
   }
@@ -254,16 +254,16 @@ import { Events, Listener, type ContextMenuCommandDeniedPayload, type UserError 
 
 export class ContextMenuCommandDenied extends Listener<typeof Events.ContextMenuCommandDenied> {
   public run(error: UserError, { interaction }: ContextMenuCommandDeniedPayload) {
-    if (Reflect.get(Object(error.context), 'silent')) return;
+    const isSilent = Reflect.get(Object(error.context), 'silent');
 
     if (interaction.deferred || interaction.replied) {
       return interaction.editReply({
-        content: error.message
+        content: isSilent ? '\u200b' : error.message
       });
     }
 
     return interaction.reply({
-      content: error.message,
+      content: isSilent ? '\u200b' : error.message
       ephemeral: true
     });
   }
@@ -274,6 +274,13 @@ export class ContextMenuCommandDenied extends Listener<typeof Events.ContextMenu
 
 </Tabs>
 
+:::caution
+
+Keep in mind that every interaction requires a reply. If you don't provide it Discord will automatically reply the user
+saying `The application did not respond`
+
+:::
+
 :::note
 
 In the code block above, we use `if (Reflect.get(Object(error.context), 'silent'))` as opposed to
@@ -281,13 +288,6 @@ In the code block above, we use `if (Reflect.get(Object(error.context), 'silent'
 
 To clarify this, with TypeScript `error.context` has the type `unknown`, so trying to write `error.context.silent` will
 throw a TypeScript error for trying to read property `silent` of type `unknown`.
-
-:::
-
-:::caution
-
-Keep in mind that every interaction requires a reply. If you don't provide it Discord will automatically reply the user
-saying `The application did not respond`
 
 :::
 

--- a/docs/Guide/preconditions/reporting-precondition-failure.mdx
+++ b/docs/Guide/preconditions/reporting-precondition-failure.mdx
@@ -284,6 +284,13 @@ throw a TypeScript error for trying to read property `silent` of type `unknown`.
 
 :::
 
+:::caution
+
+Keep in mind that every interaction requires a reply. If you don't provide it Discord will automatically reply the user
+saying `The application did not respond`
+
+:::
+
 [listeners]: ../listeners/creating-your-own-listeners
 [error]: ../../Documentation/api-framework/classes/UserError-1
 [payload-message]: ../../Documentation/api-framework/interfaces/MessageCommandDeniedPayload


### PR DESCRIPTION
The current [Reporting precondition failure](https://www.sapphirejs.dev/docs/Guide/preconditions/reporting-precondition-failure) documentation for precondition has a section teaching how to how [Ignore Precondition Failures](https://www.sapphirejs.dev/docs/Guide/preconditions/reporting-precondition-failure#ignoring-precondition-failures). 

That works like a charm if the precondition is for a command that is not an interaction command but every interaction requires a reply, if you don't provide it and ignore the command in the precondition Discord will understand that your command does not respond, and inform the user. 

This caution adds an alert for people who are implementing it for a Slash Command (interaction)