### PR TITLE
docs: updated link to TS template precondition

### DIFF
--- a/docs/Guide/preconditions/creating-your-own-preconditions.mdx
+++ b/docs/Guide/preconditions/creating-your-own-preconditions.mdx
@@ -175,5 +175,5 @@ as `AdminOnly` _or_ both `OwnerOnly` and `ModOnly`.
 [preconditions-option]: ../../Documentation/api-framework/interfaces/CommandOptions#preconditions
 [preconditions-interface]: ../../Documentation/api-framework/interfaces/Preconditions
 [preconditions-augment]:
-  https://github.com/sapphiredev/examples/blob/main/examples/with-typescript-recommended/src/preconditions/OwnerOnly.ts#L27-L31
+  https://github.com/sapphiredev/examples/blob/main/examples/with-typescript-complete/src/preconditions/OwnerOnly.ts#L27-L31
 [reporting-precondition-failure]: ./reporting-precondition-failure


### PR DESCRIPTION
The directory was renamed from `with-typescript-recommended` to `with-typescript-complete` with [`8edc19c`](https://github.com/sapphiredev/examples/commit/8edc19c0c41eefb8730baeb1bb13b5df4e3f7d4f), but the link wasn't updated.
