### PR TITLE
docs: fix TypeScript Code In Guide

### DIFF
--- a/docs/Guide/getting-started/creating-a-basic-app-command.mdx
+++ b/docs/Guide/getting-started/creating-a-basic-app-command.mdx
@@ -53,7 +53,7 @@ export class PingCommand extends Command {
     );
   }
 
-  public async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+  public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
     const msg = await interaction.reply({ content: `Ping?`, ephemeral: true, fetchReply: true });
 
     if (isMessageInstance(msg)) {


### PR DESCRIPTION
Fixed TypeScript code. The function `chatInputRun` must be overridden as it is present in the Command class, that the PingCommand class extends from.