### PR TITLE
fix: broken links in documentation

### DIFF
--- a/docs/Guide/commands/application-commands/what-are-application-commands.mdx
+++ b/docs/Guide/commands/application-commands/what-are-application-commands.mdx
@@ -33,5 +33,5 @@ starting with the [Application Command Registry][what-is-it], the next section!
 [discord-application-command-docs]: https://discord.com/developers/docs/interactions/application-commands
 [message-content-faq]:
   https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ
-[what-is-it]: ./application-command-registry/what-is-it
+[what-is-it]: ../application-command-registry/what-is-it
 [creating-a-basic-app-command]: ../../getting-started/creating-a-basic-app-command


### PR DESCRIPTION
Fixes #292

Fix the broken relative link in the documentation.

* Update the link "Application Command Registry" in `docs/Guide/commands/application-commands/what-are-application-commands.mdx` to use the correct relative path.
* Ensure the link redirects to `docs/Guide/commands/application-commands/application-command-registry/what-is-it`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sapphiredev/website/pull/294?shareId=b2418e34-afc9-42d9-8d9e-f9e962513ea6).