### PR TITLE
Fix issue with `isUserContextMenu` method in context menu interaction documentation

### DIFF
--- a/docs/Guide/commands/application-commands/application-command-registry/registering-context-commands.mdx
+++ b/docs/Guide/commands/application-commands/application-command-registry/registering-context-commands.mdx
@@ -152,7 +152,7 @@ export class SlashCommand extends Command {
 
   public override async contextMenuRun(interaction: Command.ContextMenuCommandInteraction) {
     // Use isUserContextMenu() to ensure this command was executed as a User Context Menu Command
-    if (interaction.isUserContextMenu() && interaction.targetMember instanceof GuildMember) {
+    if (interaction.isUserContextMenuCommand() && interaction.targetMember instanceof GuildMember) {
       await interaction.targetMember.ban({
         days: 8,
         reason: 'Banned for for breaking the rules.'


### PR DESCRIPTION
This pull request addresses an issue in the context menu interaction where the method `isUserContextMenu` does not exist on type `ContextMenuCommandInteraction<CacheType>`. The method has been correctly updated to `isUserContextMenuCommand`.

#### Changes Made:
- Updated the method from `isUserContextMenu` to `isUserContextMenuCommand` in the `contextMenuRun` 
![image](https://github.com/user-attachments/assets/e180e877-0c75-45e4-adbd-f0aecd9811e1)
