### PR TITLE
Update creating-your-own-arguments.mdx

### DIFF
--- a/docs/Guide/arguments/creating-your-own-arguments.mdx
+++ b/docs/Guide/arguments/creating-your-own-arguments.mdx
@@ -43,9 +43,11 @@ folder here!) of your project, then put the following code using the name of you
 :::
 
 ```typescript {2-4} showLineNumbers
+import { type TextBasedChannelTypes } from '@sapphire/discord.js-utilities';
+
 declare module '@sapphire/framework' {
   interface ArgType {
-    textBasedChannels: string;
+    textBasedChannels: TextBasedChannelTypes;
   }
 }
 


### PR DESCRIPTION
The augmentation was incorrect, in the generic there is `TextBasedChannelTypes` which should return be a return type, and in the augmentation a string is returned.